### PR TITLE
Grammar improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,8 @@ If any grammar or format errors are found, they are printed to stdout and the co
 
 - Add package to pip.
 - Checks for procedure, variable, function and signal names (enforce camel_case or snakeCase).
+
+## References
+
+- ABB RAPID [docs](https://library.e.abb.com/public/f23f1c3e506a4383b635cff165cc6993/3HAC050946+TRM+RAPID+Kernel+RW+6-en.pdf?x-sign=oUq9VZeSx%2Fve4%2BCCAYZVeAQoLxtMdzw6S2BkJobVIFhUVtPrZ8dmV1VIHdk%2B6Yfg)
+- [PyParsing](https://pyparsing-docs.readthedocs.io/en/latest/)

--- a/rapidchecker/parser/grammar.py
+++ b/rapidchecker/parser/grammar.py
@@ -23,10 +23,11 @@ stmt_block = pp.Forward()
 stmt = pp.Forward()
 
 # Arguments for proc and functon calls
-named_arg = pp.Combine("\\" + identifier) + pp.Optional(":=" + expression)
-unnamed_arg = pp.Optional(identifier + ":=") + expression
-argument = ("," + (named_arg | unnamed_arg)) | named_arg
-argument_list = pp.Optional(named_arg | unnamed_arg) + pp.ZeroOrMore(argument)
+optional_arg = pp.Combine("\\" + identifier) + pp.Optional(":=" + expression)
+required_arg = pp.Optional(identifier + ":=") + expression
+first_argument = optional_arg | required_arg
+argument = ("," + (optional_arg | required_arg)) | optional_arg
+argument_list = pp.Optional(first_argument + pp.ZeroOrMore(argument))
 
 function_call = identifier + "(" - argument_list - ")"
 

--- a/rapidchecker/parser/grammar.py
+++ b/rapidchecker/parser/grammar.py
@@ -22,10 +22,12 @@ expression = pp.Forward()
 stmt_block = pp.Forward()
 stmt = pp.Forward()
 
-# Function call
+# Arguments for proc and functon calls
 named_arg = pp.Combine("\\" + identifier) + pp.Optional(":=" + expression)
-# TODO: Allow missing commas before named args
-argument_list = pp.Optional(pp.delimitedList(named_arg | expression))
+unnamed_arg = pp.Optional(identifier + ":=") + expression
+argument = ("," + (named_arg | unnamed_arg)) | named_arg
+argument_list = pp.Optional(named_arg | unnamed_arg) + pp.ZeroOrMore(argument)
+
 function_call = identifier + "(" - argument_list - ")"
 
 array = "[" + pp.delimitedList(expression) + "]"

--- a/rapidchecker/parser/grammar.py
+++ b/rapidchecker/parser/grammar.py
@@ -60,7 +60,7 @@ var_def = (
     (T.PERS | T.VAR | T.CONST)
     + datatype
     + identifier
-    + pp.Optional("{" + pp.pyparsing_common.integer + "}")
+    + pp.Optional("{" + expression + "}")
     + pp.Optional(":=" + expression)
     + ";"
 )

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -17,7 +17,7 @@ from rapidchecker.parser.grammar import (
     function_call,
     if_stmt,
     module,
-    named_arg,
+    optional_arg,
     proc_call_stmt,
     proc_def,
     record_def,
@@ -76,8 +76,8 @@ def test_stmt_block(valid_block: str) -> None:
 
 
 @pytest.mark.parametrize("input_str", ["\\a", "\\a:=c"])
-def test_named_arg(input_str: str) -> None:
-    assert named_arg.parseString(input_str, parseAll=True).as_list()
+def test_optional_arg(input_str: str) -> None:
+    assert optional_arg.parseString(input_str, parseAll=True).as_list()
 
 
 @pytest.mark.parametrize("input_str", ["\\a", "\\a, \\b:=c", "\\a, c+1", "a, \\b:=c"])

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -140,6 +140,7 @@ def test_record_def(input_str: str) -> None:
     [
         "PERS string varName;",
         "VAR robtarget targets{1000};",
+        "VAR robtarget targets{var1 + var2};",
         "CONST num number := 1 + 1;",
     ],
 )

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -236,6 +236,7 @@ def test_for_stmt(input_str: str) -> None:
         "callProc arg1, arg2, A AND B;",
         "callProc arg1, arg2, \\switch;",
         "callProc arg1, arg2, \\opt:=(1+1), \\switch;",
+        "callProc arg1, name:=arg2 \\opt:=(1+1) \\switch;",
     ],
 )
 def test_proc_call_stmt(input_str: str) -> None:
@@ -249,6 +250,7 @@ def test_proc_call_stmt(input_str: str) -> None:
         "callFunc(arg1, arg2, A AND B);",
         "callFunc(arg1, arg2, \\switch);",
         "callFunc(arg1, arg2, \\opt:=(1+1), \\switch);",
+        "callFunc(arg1, name:=arg2 \\opt:=(1+1) \\switch);",
     ],
 )
 def test_func_call_stmt(input_str: str) -> None:


### PR DESCRIPTION
1. Allow expressions in the array size e.g `VAR myarray{num1+num2}`
2. Don't require commas for optional arguments e.g `procCall arg1, arg2 \switch` instead of `procCall arg1, arg2, \switch`