### PR TITLE
Change indentation for error sections

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rapidchecker"
-version = "0.1.1"
+version = "0.1.2"
 description = " Grammar and format checker for ABB RAPID code. "
 readme = "README.md"
 requires-python = ">=3.10"

--- a/rapidchecker/config.py
+++ b/rapidchecker/config.py
@@ -11,6 +11,7 @@ class Config:
     max_empty_lines: int = 2
     require_new_line_eof: bool = True
     allow_trailing_space: bool = False
+    indent_error_section: bool = False
 
     @classmethod
     def read_config(cls, config_file: Path) -> "Config":

--- a/rapidchecker/parser/grammar.py
+++ b/rapidchecker/parser/grammar.py
@@ -1,5 +1,7 @@
 import pyparsing as pp
 
+from rapidchecker.config import CONFIG
+
 from . import tokens as T
 from .identifiers import datatype, identifier, parameter_list, variable
 from .indent import (
@@ -149,7 +151,10 @@ func_def = (
 )
 
 # Proc definition
-error_section = T.ERROR - stmt_block
+if CONFIG.indent_error_section:
+    error_section = T.ERROR - INDENT - stmt_block - UNDENT
+else:
+    error_section = INDENT_CHECKPOINT + T.ERROR - stmt_block
 proc_def = (
     T.PROC
     - identifier

--- a/rapidchecker/parser/identifiers.py
+++ b/rapidchecker/parser/identifiers.py
@@ -16,7 +16,7 @@ variable.set_name("variable")
 
 parameter = (
     pp.Optional("\\")
-    + pp.Optional(T.INOUT | T.PERS)
+    + pp.Optional(T.INOUT | T.PERS | T.VAR)
     + datatype
     + identifier
     + elem_index

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -307,7 +307,7 @@ def test_func_def(input_str: str) -> None:
     [
         "PROC procName()\nENDPROC",
         "PROC procName(num arg1, \\num arg2, \\switch aa)\n  statement;\n  statement2;\nENDPROC",
-        "PROC procName(num arg1, \\num arg2, \\switch aa)\n  statement;\n  ERROR\n  statement2;\nENDPROC",
+        "PROC procName(num arg1, \\num arg2, \\switch aa)\n  statement;\nERROR\n  statement2;\nENDPROC",
     ],
 )
 def test_proc_def(input_str: str) -> None:

--- a/tests/test_identifiers.py
+++ b/tests/test_identifiers.py
@@ -53,6 +53,7 @@ def test_invalid_variable(invalid_variable: str) -> None:
         "\\INOUT string name{100}",
         "string name",
         "\\robtarget target",
+        "VAR signaldo signal",
     ],
 )
 def test_parameter(valid_parameter: str) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -286,7 +286,7 @@ wheels = [
 
 [[package]]
 name = "rapidchecker"
-version = "0.1.1"
+version = "0.1.2"
 source = { virtual = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Error sections in procedures can now follow one of the two indentation formats

With `indent_error_section=true`
```
PROC procname()
    MoveL target;
    ERROR 
        HandleError;
ENDPROC
```

With `indent_error_section=false`
```
PROC procname()
    MoveL target;
ERROR 
    HandleError;
ENDPROC
```

Bonus: Allowed `VAR` in parameter definition