### PR TITLE
Pass path list to CLI instead of a folder

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rapidchecker"
-version = "0.1.2"
+version = "0.1.3"
 description = " Grammar and format checker for ABB RAPID code. "
 readme = "README.md"
 requires-python = ">=3.10"

--- a/rapidchecker/cli.py
+++ b/rapidchecker/cli.py
@@ -24,15 +24,11 @@ def check_file(file_contents: str) -> list[ParseBaseException | WhiteSpaceError]
 
 
 @click.command()
-@click.argument("path", type=click.Path(exists=True))
-@click.option("--ignore", multiple=True)
-def cli(path: str, ignore: list[str]) -> None:
+@click.argument("paths", nargs=-1, type=click.Path(exists=True, dir_okay=False))
+def cli(paths: list[str]) -> None:
     found_errors = False
 
-    for filepath in get_sys_files(path):
-        if in_ignore_list(str(filepath), ignore):
-            print("Skipping", filepath)
-            continue
+    for filepath in paths:
         errors = check_file(read_sys_file(filepath))
         if not errors:
             continue


### PR DESCRIPTION
Previously the CLI would accept a folder and do a recursive search to find SYS files. This is not very flexible. 

Instead, the CLI will now accept a list of paths. If the user wants to do a recursive search in a folder, they can still use `/**/*.sys` 